### PR TITLE
README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Install the plugin via npm with
 npm install --save groundskeeper-brunch
 ```
 
+If you are using [uglify-js-brunch](https://github.com/brunch/uglify-js-brunch) or other JS obfuscation packages make sure that `groundskeeper-brunch` is defined **before** them in your `package.json`.
+
 ## Usage
 
 To specify groundskeeper options, use `config.plugins.groundskeeper` object, for example:


### PR DESCRIPTION
groundskeeper doesn't play that nicely with minified code.
doing this makes sure that `groundskeeper-brunch` is run before in brunch's optimization step.

I got a problem where I had some code which, when obfuscated was `[..],console.log('something'),[..]` and groundskeeper removed the `console.log` but kept both the commas, resulting in a syntax error when run.
